### PR TITLE
Update SynologyRequest.cs

### DIFF
--- a/Synology/Classes/SynologyRequest.cs
+++ b/Synology/Classes/SynologyRequest.cs
@@ -30,7 +30,7 @@ namespace Synology.Classes
                 if (ta != null)
                     res.Insert(0, ta.Name);
 
-                ty = ty.BaseType.GetTypeInfo();
+                ty = ty.BaseType?.GetTypeInfo();
             }
 
             return string.Join(".", res);


### PR DESCRIPTION
Update the GetApiName method.
When reaching ty = Object, the BaseType is null causing an exception